### PR TITLE
Version APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ RECOVER_*.fla
 
 # Jetbrains tools (CLion, IntelliJ, etc)
 /.idea
-

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ RECOVER_*.fla
 
 # Jetbrains tools (CLion, IntelliJ, etc)
 /.idea
+

--- a/core/src/avm2/globals/flash/desktop/Icon.as
+++ b/core/src/avm2/globals/flash/desktop/Icon.as
@@ -6,7 +6,7 @@
 package flash.desktop
 {
   import flash.events.EventDispatcher;
-
+  [API("661")]
   public class Icon extends EventDispatcher
   {
 

--- a/core/src/avm2/globals/flash/desktop/InteractiveIcon.as
+++ b/core/src/avm2/globals/flash/desktop/InteractiveIcon.as
@@ -5,7 +5,7 @@
 
 package flash.desktop
 {
-
+  [API("661")]
   public class InteractiveIcon extends Icon
   {
     // The current display height of the icon in pixels.

--- a/core/src/avm2/globals/flash/desktop/NativeApplication.as
+++ b/core/src/avm2/globals/flash/desktop/NativeApplication.as
@@ -12,6 +12,7 @@ package flash.desktop
   import __ruffle__.stub_getter;
   import __ruffle__.stub_setter;
 
+  [API("661")]
   public final class NativeApplication extends EventDispatcher
   {
     private static var _instance:NativeApplication;
@@ -54,12 +55,14 @@ package flash.desktop
       return false;
     }
 
+    [API("668")]
     public static function get supportsDefaultApplication():Boolean
     {
       stub_getter("flash.desktop.NativeApplication", "supportsDefaultApplication");
       return false;
     }
 
+    [API("668")]
     public static function get supportsStartAtLogin():Boolean
     {
       stub_getter("flash.desktop.NativeApplication", "supportsStartAtLogin");
@@ -122,12 +125,14 @@ package flash.desktop
       return null;
     }
 
+    [API("668")]
     public function get systemIdleMode():String
     {
       stub_getter("flash.desktop.NativeApplication", "systemIdleMode");
       return "normal";
     }
 
+    [API("668")]
     public function set systemIdleMode(param1:String):void
     {
       stub_setter("flash.desktop.NativeApplication", "systemIdleMode");
@@ -229,17 +234,20 @@ package flash.desktop
       stub_method("flash.desktop.NativeApplication", "removeAsDefaultApplication");
     }
 
+    [API("681")]
     public function get executeInBackground():Boolean
     {
       stub_getter("flash.desktop.NativeApplication", "executeInBackground");
       return false;
     }
 
+    [API("681")]
     public function set executeInBackground(param1:Boolean):void
     {
       stub_setter("flash.desktop.NativeApplication", "executeInBackground");
     }
 
+    [API("721")]
     public function get isCompiledAOT():Boolean
     {
       stub_getter("flash.desktop.NativeApplication", "isCompiledAOT");

--- a/core/src/avm2/globals/flash/display/NativeMenu.as
+++ b/core/src/avm2/globals/flash/display/NativeMenu.as
@@ -9,7 +9,8 @@ package flash.display
     import flash.events.EventDispatcher;
     import __ruffle__.stub_method;
     import __ruffle__.stub_getter;
-
+    
+    [API("661")]
     public class NativeMenu extends EventDispatcher
     {
 
@@ -125,6 +126,7 @@ package flash.display
             stub_method("flash.display.NativeMenu", "setItemIndex");
         }
 
+        [API("668")]
         public function get isSupported():Boolean
         {
             return this._isSupported;

--- a/core/src/avm2/globals/flash/display/NativeMenuItem.as
+++ b/core/src/avm2/globals/flash/display/NativeMenuItem.as
@@ -1,5 +1,7 @@
 package flash.display {
     import flash.events.EventDispatcher;
+
+    [API("661")]
     public class NativeMenuItem extends EventDispatcher {
         public var enabled: Boolean;
     }

--- a/core/src/avm2/globals/flash/display/NativeWindow.as
+++ b/core/src/avm2/globals/flash/display/NativeWindow.as
@@ -10,7 +10,8 @@ package flash.display
   import __ruffle__.stub_getter;
   import __ruffle__.stub_setter;
   import __ruffle__.stub_constructor;
-
+  
+  [API("661")]
   public class NativeWindow extends EventDispatcher
   {
     public const systemMaxSize:Point = new Point(2880, 2880);
@@ -185,6 +186,7 @@ package flash.display
     }
 
     // Returns a list of the NativeWindow objects that are owned by this window.
+    [API("671")]
     public function listOwnedWindows():Vector.<NativeWindow>
     {
       stub_method("flash.display.NativeWindow", "listOwnedWindows");
@@ -273,24 +275,27 @@ package flash.display
       return "normal";
     }
 
+    [API("668")]
     public function get isSupported():Boolean
     {
       stub_getter("flash.display.NativeWindow", "isSupported");
       return false;
     }
 
+    [API("671")]
     public function get owner():NativeWindow
     {
       stub_getter("flash.display.NativeWindow", "owner");
       return this;
     }
 
+    [API("675")]
     public function get renderMode():String
     {
       stub_getter("flash.display.NativeWindow", "renderMode");
       return "auto";
     }
-
+    
     public function get supportsMenu():Boolean
     {
       stub_getter("flash.display.NativeWindow", "supportsMenu");
@@ -303,6 +308,7 @@ package flash.display
       return false;
     }
 
+    [API("661")]
     public function get supportsTransparency():Boolean
     {
       stub_getter("flash.display.NativeWindow", "supportsTransparency");

--- a/core/src/avm2/globals/flash/display/NativeWindowDisplayState.as
+++ b/core/src/avm2/globals/flash/display/NativeWindowDisplayState.as
@@ -1,5 +1,6 @@
 package flash.display
 {
+  [API("661")]
   public final class NativeWindowDisplayState
   {
     public static const MAXIMIZED:String = "maximized";

--- a/core/src/avm2/globals/flash/display/NativeWindowInitOptions.as
+++ b/core/src/avm2/globals/flash/display/NativeWindowInitOptions.as
@@ -5,6 +5,7 @@
 
 package flash.display
 {
+  [API("661")]
   public class NativeWindowInitOptions
   {
 
@@ -15,9 +16,11 @@ package flash.display
     public var minimizable:Boolean;
 
     // Specifies the NativeWindow object that should own any windows created with this NativeWindowInitOptions.
+    [API("671")]
     public var owner:NativeWindow;
 
     // Specifies the render mode of the NativeWindow object created with this NativeWindowInitOptions.
+    [API("675")]
     public var renderMode:String;
 
     // Specifies whether the window can be resized by the user.
@@ -34,7 +37,13 @@ package flash.display
 
     public function NativeWindowInitOptions()
     {
-
+      systemChrome = NativeWindowSystemChrome.STANDARD;
+      type = NativeWindowType.NORMAL;
+      transparent = false;
+      owner = null;
+      resizable = true;
+      maximizable = true;
+      minimizable = true;
     }
 
   }

--- a/core/src/avm2/globals/flash/display/NativeWindowSystemChrome.as
+++ b/core/src/avm2/globals/flash/display/NativeWindowSystemChrome.as
@@ -1,0 +1,10 @@
+package flash.display
+{
+  [API("661")]
+  public final class NativeWindowSystemChrome
+  {
+    public static const ALTERNATE:String = "alternate";
+    public static const NONE:String = "none";
+    public static const STANDARD:String = "standard";
+  }
+}

--- a/core/src/avm2/globals/flash/display/NativeWindowType.as
+++ b/core/src/avm2/globals/flash/display/NativeWindowType.as
@@ -1,0 +1,10 @@
+package flash.display
+{
+    public final class NativeWindowType
+    {
+        [API("661")]
+        public static const LIGHTWEIGHT:String = "lightweight";
+        public static const NORMAL:String = "normal";
+        public static const UTILITY:String = "utility";
+    }
+}

--- a/core/src/avm2/globals/flash/display/Screen.as
+++ b/core/src/avm2/globals/flash/display/Screen.as
@@ -3,12 +3,14 @@ package flash.display
   import __ruffle__.stub_getter;
   import flash.geom.Rectangle;
 
-  public class Screen
+  [API("661")]
+  public final class Screen
   {
     private static var _screens:Array;
     private var _width:int;
     private var _height:int;
 
+    [API("733")]
     public var mode:ScreenMode;
 
     public function Screen(width:int, height:int)
@@ -54,6 +56,7 @@ package flash.display
       return bounds;
     }
 
+    [API("733")]
     public function get modes():Array
     {
       stub_getter("flash.display.Screen", "modes");

--- a/core/src/avm2/globals/flash/display/ScreenMode.as
+++ b/core/src/avm2/globals/flash/display/ScreenMode.as
@@ -3,6 +3,7 @@ package flash.display
   import __ruffle__.stub_getter;
   import flash.geom.Rectangle;
 
+  [API("733")]
   public class ScreenMode
   {
     private var _width:int;

--- a/core/src/avm2/globals/flash/display/Stage.as
+++ b/core/src/avm2/globals/flash/display/Stage.as
@@ -323,6 +323,7 @@ package flash.display {
             stub_method("flash.display.Stage", "setAspectRatio");
         }
         
+        [API("661")]
         public function get nativeWindow():NativeWindow {
             if (!this._nativeWindow) {
                 this._nativeWindow = new NativeWindow(new NativeWindowInitOptions(), this);

--- a/core/src/avm2/globals/flash/events/Event.as
+++ b/core/src/avm2/globals/flash/events/Event.as
@@ -17,6 +17,7 @@ package flash.events {
 
 		public static const CLOSE:String = "close";
 
+		[API("661")]
 		public static const CLOSING:String = "closing";
 
 		public static const COMPLETE:String = "complete";
@@ -33,8 +34,7 @@ package flash.events {
 
 		public static const FRAME_CONSTRUCTED:String = "frameConstructed";
 
-		public static const EXIT:String = "exit";
-
+		[API("661")]
 		public static const EXITING:String = "exiting";
 
 		public static const EXIT_FRAME:String = "exitFrame";

--- a/core/src/avm2/globals/flash/events/HTMLUncaughtScriptExceptionEvent.as
+++ b/core/src/avm2/globals/flash/events/HTMLUncaughtScriptExceptionEvent.as
@@ -5,7 +5,7 @@
 
 package flash.events
 {
-
+  [API("661")]
   public class HTMLUncaughtScriptExceptionEvent extends Event
   {
 

--- a/core/src/avm2/globals/flash/events/InvokeEvent.as
+++ b/core/src/avm2/globals/flash/events/InvokeEvent.as
@@ -8,6 +8,7 @@ package flash.events
 
   import flash.filesystem.File;
 
+  [API("661")]
   public class InvokeEvent extends Event
   {
     public static const INVOKE:String = "invoke";
@@ -40,6 +41,7 @@ package flash.events
       return this._arguments;
     }
 
+    [API("664")]
     public function get reason():String
     {
       return this._reason;

--- a/core/src/avm2/globals/flash/events/NativeWindowBoundsEvent.as
+++ b/core/src/avm2/globals/flash/events/NativeWindowBoundsEvent.as
@@ -8,6 +8,7 @@ package flash.events
 
   import flash.geom.Rectangle;
 
+  [API("661")]
   public class NativeWindowBoundsEvent extends Event
   {
     public static const RESIZE:String = "resize";

--- a/core/src/avm2/globals/flash/events/NativeWindowDisplayStateEvent.as
+++ b/core/src/avm2/globals/flash/events/NativeWindowDisplayStateEvent.as
@@ -5,7 +5,7 @@
 
 package flash.events
 {
-
+  [API("661")]
   public class NativeWindowDisplayStateEvent extends Event
   {
     public static const DISPLAY_STATE_CHANGE:String = "displayStateChange";

--- a/core/src/avm2/globals/flash/filesystem/File.as
+++ b/core/src/avm2/globals/flash/filesystem/File.as
@@ -8,6 +8,7 @@ package flash.filesystem
   import __ruffle__.stub_getter;
 
   [Ruffle(InstanceAllocator)]
+  [API("661")]
   public class File extends FileReference
   {
     private static var _applicationStorageDirectory:File;
@@ -31,6 +32,7 @@ package flash.filesystem
       }
     }
 
+    [API("681")]
     public static function get permissionStatus():String
     {
       stub_method("flash.net.FileReference", "permissionStatus");
@@ -128,11 +130,13 @@ package flash.filesystem
       stub_method("flash.filesystem.File", "openWithDefaultApplication");
     }
 
+    [API("668")]
     public function get downloaded():Boolean
     {
       stub_getter("flash.filesystem.File", "downloaded");
     }
 
+    [API("668")]
     public function set downloaded(value:Boolean):void
     {
       stub_setter("flash.filesystem.File", "downloaded");
@@ -251,6 +255,7 @@ package flash.filesystem
     }
 
     // [override] Requests permission to access filesystem.
+    [API("681")]
     override public function requestPermission():void
     {
       // Unknown Implementation

--- a/core/src/avm2/globals/flash/filesystem/FileMode.as
+++ b/core/src/avm2/globals/flash/filesystem/FileMode.as
@@ -5,7 +5,7 @@
 
 package flash.filesystem
 {
-
+  [API("661")]
   public class FileMode
   {
     public static const APPEND:String = "append";

--- a/core/src/avm2/globals/flash/filesystem/FileStream.as
+++ b/core/src/avm2/globals/flash/filesystem/FileStream.as
@@ -12,6 +12,7 @@ package flash.filesystem
   import flash.utils.ByteArray;
 
   [Ruffle(InstanceAllocator)]
+  [API("661")]
   public class FileStream extends EventDispatcher
   {
     public var endian:String = "LITTLE_ENDIAN";

--- a/core/src/avm2/globals/flash/filesystem/StorageVolume.as
+++ b/core/src/avm2/globals/flash/filesystem/StorageVolume.as
@@ -11,6 +11,7 @@ package flash.filesystem
     import __ruffle__.stub_getter;
     import __ruffle__.stub_setter;
 
+    [API("668")]
     public class StorageVolume
     {
 

--- a/core/src/avm2/globals/flash/filesystem/StorageVolumeInfo.as
+++ b/core/src/avm2/globals/flash/filesystem/StorageVolumeInfo.as
@@ -11,6 +11,7 @@ package flash.filesystem
   import __ruffle__.stub_getter;
   import __ruffle__.stub_setter;
 
+  [API("668")]
   public final class StorageVolumeInfo extends EventDispatcher
   {
 

--- a/core/src/avm2/globals/flash/system/MessageChannel.as
+++ b/core/src/avm2/globals/flash/system/MessageChannel.as
@@ -3,7 +3,8 @@ package flash.system {
     import __ruffle__.stub_constructor;
     import __ruffle__.stub_method;
     import __ruffle__.stub_getter;
-
+    
+    [API("682")]
     public final class MessageChannel extends EventDispatcher {
         private var _state:String = MessageChannelState.OPEN;
 

--- a/core/src/avm2/globals/flash/system/MessageChannelState.as
+++ b/core/src/avm2/globals/flash/system/MessageChannelState.as
@@ -5,7 +5,7 @@
 
 package flash.system
 {
-
+    [API("682")]
     public final class MessageChannelState
     {
         // This state indicates that the message channel has been closed and doesn't have any more messages to deliver.

--- a/core/src/avm2/globals/flash/system/Worker.as
+++ b/core/src/avm2/globals/flash/system/Worker.as
@@ -4,6 +4,7 @@ package flash.system
     import __ruffle__.stub_constructor;
     import __ruffle__.stub_method;
 
+    [API("682")]
     public class Worker extends EventDispatcher
     {
         private static var _current:Worker;

--- a/core/src/avm2/globals/flash/system/WorkerDomain.as
+++ b/core/src/avm2/globals/flash/system/WorkerDomain.as
@@ -4,6 +4,7 @@ package flash.system
     import __ruffle__.stub_getter;
     import __ruffle__.stub_method;
 
+    [API("682")]
     public class WorkerDomain
     {
         public static const isSupported:Boolean = false;

--- a/core/src/avm2/globals/flash/system/WorkerState.as
+++ b/core/src/avm2/globals/flash/system/WorkerState.as
@@ -5,7 +5,7 @@
 
 package flash.system
 {
-
+    [API("682")]
     public final class WorkerState
     {
         // This state indicates that an object that represents the new worker has been created, but the worker is not executing code.


### PR DESCRIPTION
Also added the constructor for NativeWindowInitOptions, the classes NativeWindowSystemChrome and NativeWindowType, and removed the EXIT event as it doesn't exist.